### PR TITLE
adds python 3.7 compatibility

### DIFF
--- a/octoprint_stats/__init__.py
+++ b/octoprint_stats/__init__.py
@@ -1019,6 +1019,7 @@ class StatsPlugin(octoprint.plugin.EventHandlerPlugin,
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "Printer Stats"
 __plugin_version__ = "2.0.2"
+__plugin_pythoncompat__ = ">=2.7,<4"
 __plugin_description__ = "Statistics of your 3D Printer"
 
 def __plugin_load__():

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/amsbr/OctoPrint-Stats"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["tinydb", "pandas"]
+plugin_requires = ["tinydb", "pandas", "numpy"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
I upgraded to Python 3.7 and I could not run your plug-in.

I got the following error: "Plugin Printer Stats (2.0.2) is not compatible to Python 3.7.3 (compatibility string: >=2.7,<3)."

So I just added the __plugin_pythoncompat__ information and run this plugin. I had a big issue with numpy under Raspbian even with a fresh installation:

```
ImportError: Unable to import required dependencies:
numpy:
IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
Importing the numpy c-extensions failed.
- Try uninstalling and reinstalling numpy.
- If you have already done that, then:
  1. Check that you expected to use Python3.7 from "/home/octopi/OctoPrint/venv/bin/python",
     and that you have no directories in your PATH or PYTHONPATH that can
     interfere with the Python and numpy version "1.18.1" you're trying to use.
  2. If (1) looks fine, you can open a new issue at
     https://github.com/numpy/numpy/issues.  Please include details on:
     - how you installed Python
     - how you installed numpy
     - your operating system
     - whether or not you have multiple versions of Python installed
     - if you built from source, your compiler versions and ideally a build log
- If you're working with a numpy git repository, try `git clean -xdf`
  (removes all files not under version control) and rebuild numpy.
Note: this error has many possible causes, so please don't comment on
an existing issue about this - open a new one instead.
Original error was: libf77blas.so.3: cannot open shared object file: No such file or directory
```

I had to install a package for numpy to work correctly:

```
apt install libatlas-base-dev
```

Without that package it won't work and run always into the numpy error.

Now it works like a charm with Python 3.7.3 and I had no issue with my OctoPrint setup.
